### PR TITLE
Remove hubot-shipit

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -7,7 +7,6 @@
   "hubot-maps",
   "hubot-redis-brain",
   "hubot-rules",
-  "hubot-shipit",
   "hubot-sonny",
   "hubot-uptime",
   "hubot-restart",


### PR DESCRIPTION
Per multiple sources, bots and/or commands that pollute the channel or answer un-necessarily are bad Slack etiquette.

- https://hiverhq.com/blog/slack-etiquette
- https://slatiquette.com/

Although you are not the owner of hubot-shipit, please consider removing it as a dependency here because of this reason.